### PR TITLE
feat(property-purchase): implement escrow-based property purchase flo…

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -46,6 +46,10 @@ class Kernel extends ConsoleKernel
         $schedule->command('system:health-check')
             ->everyFifteenMinutes()
             ->withoutOverlapping();
+
+                // Release property escrows automatically
+    $schedule->command('escrow:release')->everyMinute();
+
     }
 
     /**
@@ -57,4 +61,5 @@ class Kernel extends ConsoleKernel
 
         require base_path('routes/console.php');
     }
+    
 }

--- a/app/Enums/NotificationPurpose.php
+++ b/app/Enums/NotificationPurpose.php
@@ -43,6 +43,14 @@ enum NotificationPurpose: string
     case EMAIL_OTP = 'email_otp';
     case PASSWORD_RESET = 'password_reset';
 
+    // Property purchase lifecycle
+    case PROPERTY_PURCHASE_REQUESTED = 'property_purchase_requested';
+    case PURCHASE_INITIATED          = 'purchase_initiated';
+    case PURCHASE_COMPLETED          = 'purchase_completed';
+    case PURCHASE_CANCELLED          = 'purchase_cancelled';
+    case PURCHASE_FAILED             = 'purchase_failed';
+
+
     /**
      * Get a human-readable label for the purpose
      */
@@ -74,6 +82,12 @@ enum NotificationPurpose: string
             self::CHECKOUT_REFUND_PROCESSED => 'Checkout Refund Processed',
             self::EMAIL_OTP => 'Email OTP',
             self::PASSWORD_RESET => 'Password Reset',
+            self::PROPERTY_PURCHASE_REQUESTED => 'Property Purchase Requested',
+            self::PURCHASE_INITIATED          => 'Purchase Initiated',
+            self::PURCHASE_COMPLETED          => 'Purchase Completed',
+            self::PURCHASE_CANCELLED          => 'Purchase Cancelled',
+            self::PURCHASE_FAILED             => 'Purchase Failed',
+
         };
     }
 

--- a/app/Http/Controllers/PropertyPurchaseController.php
+++ b/app/Http/Controllers/PropertyPurchaseController.php
@@ -1,0 +1,352 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Property;
+use App\Models\PropertyPurchase;
+use App\Models\PropertyEscrow;
+use App\Models\Wallet;
+use App\Models\RentRequest;
+use App\Models\WalletTransaction;
+use App\Models\UserNotification;
+use App\Enums\NotificationPurpose;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+use Carbon\Carbon;
+use Exception;
+
+class PropertyPurchaseController extends Controller
+{
+    // ====================================================
+    // Helpers for uniform responses
+    // ====================================================
+    protected function success($message, $data = null, $status = 200)
+    {
+        $payload = ['success' => true, 'message' => $message];
+        if (!is_null($data)) {
+            $payload['data'] = $data;
+        }
+        return response()->json($payload, $status);
+    }
+
+    protected function error($message, $status = 422, $details = null)
+    {
+        $payload = ['success' => false, 'message' => $message];
+        if (!is_null($details)) {
+            $payload['errors'] = $details;
+        }
+        return response()->json($payload, $status);
+    }
+
+    // ====================================================
+    // Persist notifications into user_notifications table
+    // ====================================================
+    private function createUserNotificationFromWebsocketData(
+        $recipient,
+        $notificationClass,
+        NotificationPurpose $purpose,
+        $senderId = null
+    ) {
+        try {
+            $notificationData = null;
+            if (method_exists($notificationClass, 'toDatabase')) {
+                $notificationData = $notificationClass->toDatabase($recipient);
+            } elseif (method_exists($notificationClass, 'toBroadcast')) {
+                $broadcastData = $notificationClass->toBroadcast($recipient);
+                $notificationData = $broadcastData->data ?? $broadcastData;
+            }
+
+            $entityId = $notificationData['purchase_id'] ?? $notificationData['property_id'] ?? null;
+            $message  = $notificationData['message'] ?? 'New notification';
+
+            UserNotification::create([
+                'user_id'   => $recipient->id,
+                'sender_id' => $senderId,
+                'entity_id' => $entityId,
+                'purpose'   => $purpose,
+                'title'     => $purpose->label(),
+                'message'   => $message,
+                'is_read'   => false,
+            ]);
+        } catch (Exception $e) {
+            Log::warning('Failed to create UserNotification', [
+                'error' => $e->getMessage(),
+                'recipient_id' => $recipient->id ?? null,
+            ]);
+        }
+    }
+
+    // ====================================================
+    // PAY FOR PROPERTY
+    // ====================================================
+    public function payForOwn(Request $request, $id)
+    {
+        $validator = \Validator::make($request->all(), [
+            'payment_method_token' => 'nullable|string',
+            'idempotency_key'      => 'nullable|string',
+            'expected_total'       => 'required|numeric|min:0',
+        ]);
+
+        if ($validator->fails()) {
+            return $this->error('Validation failed.', 422, $validator->errors());
+        }
+
+        $user = $request->user();
+        if (!$user) return $this->error('Authentication required.', 401);
+        if ($user->status !== 'active') return $this->error('Your account must be active.', 403);
+
+        $idempotencyKey = $request->input('idempotency_key') ?? Str::uuid()->toString();
+        $paymentToken   = $request->input('payment_method_token');
+        $expectedTotal  = $request->input('expected_total');
+
+        try {
+            return DB::transaction(function () use ($id, $user, $idempotencyKey, $paymentToken, $expectedTotal) {
+                // Idempotency
+                $existingPurchase = PropertyPurchase::with('escrow')
+                    ->where('idempotency_key', $idempotencyKey)
+                    ->first();
+                if ($existingPurchase) {
+                    return $this->success('Purchase already processed.', [
+                        'purchase' => $existingPurchase,
+                        'escrow'   => $existingPurchase->escrow,
+                        'property' => $existingPurchase->property,
+                        'seller'   => $existingPurchase->seller,
+                    ]);
+                }
+
+                // Property checks
+                $property = Property::lockForUpdate()->find($id);
+                if (!$property) return $this->error('Property not found.', 404);
+                if ($property->status !== 'sale' || $property->property_state !== 'Valid') {
+                    return $this->error('This property is not valid for sale.', 422);
+                }
+
+                // Seller must exist and be active
+                $seller = $property->owner;
+                if (!$seller || $seller->status !== 'active') {
+                    return $this->error('Property owner is not active.', 422);
+                }
+
+                if ($property->owner_id === $user->id) {
+                    return $this->error('You cannot buy your own property.', 422);
+                }
+
+                // Ensure buyer did not already buy this property
+                $alreadyPurchased = PropertyPurchase::where('buyer_id', $user->id)
+                    ->where('property_id', $property->id)
+                    ->whereNotIn('status', ['cancelled', 'refunded'])
+                    ->exists();
+                if ($alreadyPurchased) {
+                    return $this->error('You already purchased this property.', 422);
+                }
+
+                // Price validation
+                $totalAmount = $property->price;
+                if (abs($totalAmount - $expectedTotal) > 0.01) {
+                    return $this->error('Price mismatch.', 422);
+                }
+
+                // 1. Create purchase
+                $purchase = PropertyPurchase::create([
+                    'property_id'          => $property->id,
+                    'buyer_id'             => $user->id,
+                    'seller_id'            => $property->owner_id,
+                    'amount'               => $totalAmount,
+                    'status'               => 'paid',
+                    'payment_gateway'      => $paymentToken ? 'gateway' : 'Wallet',
+                    'transaction_ref'      => Str::uuid()->toString(),
+                    'idempotency_key'      => $idempotencyKey,
+                    'cancellation_deadline'=> now()->addHours(24),
+                    'metadata'             => [
+                        'wallet_used'     => $totalAmount,
+                        'gateway_charged' => 0,
+                    ],
+                ]);
+
+                // 2. Create escrow
+                $escrow = PropertyEscrow::create([
+                    'property_purchase_id' => $purchase->id,
+                    'property_id'          => $property->id,
+                    'buyer_id'             => $user->id,
+                    'seller_id'            => $property->owner_id,
+                    'amount'               => $totalAmount,
+                    'status'               => 'locked',
+                    'locked_at'            => now(),
+                    'scheduled_release_at' => now()->addHours(24),
+                ]);
+
+                // 3. Mark property invalid immediately
+                $property->update([
+                    'property_state'   => 'Invalid',
+                    'pending_buyer_id' => $user->id,
+                ]);
+
+                // 4. Notifications
+                try {
+                    // Buyer notification
+                    $buyerNotification = new \App\Notifications\PropertyPurchaseInitiated($purchase);
+                    Notification::send($user, $buyerNotification);
+                    $this->createUserNotificationFromWebsocketData(
+                        $user,
+                        $buyerNotification,
+                        NotificationPurpose::PURCHASE_INITIATED,
+                        $property->owner_id
+                    );
+
+                    // Seller notification
+                    $sellerNotification = new \App\Notifications\PurchaseInitiatedSeller($purchase);
+                    Notification::send($seller, $sellerNotification);
+                    $this->createUserNotificationFromWebsocketData(
+                        $seller,
+                        $sellerNotification,
+                        NotificationPurpose::PROPERTY_PURCHASE_REQUESTED,
+                        $user->id
+                    );
+                } catch (Exception $e) {
+                    Log::warning('Notification failed on payForOwn', ['error' => $e->getMessage()]);
+                }
+
+                return $this->success('Purchase successful.', [
+                    'purchase' => $purchase,
+                    'escrow'   => $escrow,
+                    'property' => $property,
+                    'seller'   => $seller, // return owner data
+                ]);
+            });
+        } catch (\Throwable $e) {
+            Log::error('payForOwn error: '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);
+            return $this->error('Property purchase failed.', 500);
+        }
+    }
+
+    // ====================================================
+    // CANCEL PURCHASE
+    // ====================================================
+    public function cancelPurchase(Request $request, $purchaseId)
+    {
+        $user = $request->user();
+        if (!$user) {
+            return $this->error('Authentication required.', 401);
+        }
+
+        $purchase = PropertyPurchase::with('escrow', 'property', 'seller')
+            ->where('id', $purchaseId)
+            ->first();
+
+        if (!$purchase) {
+            return $this->error('Purchase not found.', 404);
+        }
+
+        if ($purchase->buyer_id !== $user->id) {
+            return $this->error('Only the buyer can cancel this purchase.', 403);
+        }
+
+        $escrow = $purchase->escrow;
+        if (!$escrow || $escrow->status !== 'locked') {
+            return $this->error('Purchase cannot be cancelled.', 422);
+        }
+
+        if ($escrow->scheduled_release_at->isPast()) {
+            return $this->error('Cancellation window has expired.', 422);
+        }
+
+        return DB::transaction(function () use ($purchase, $escrow, $user) {
+            $wallet = Wallet::lockForUpdate()->firstOrCreate(
+                ['user_id' => $user->id],
+                ['balance' => 0]
+            );
+            $before = $wallet->balance;
+            $wallet->increment('balance', $escrow->amount);
+
+            WalletTransaction::create([
+                'wallet_id'       => $wallet->id,
+                'amount'          => $escrow->amount,
+                'type'            => 'refund',
+                'ref_id'          => $purchase->id,
+                'ref_type'        => 'property_purchase',
+                'description'     => 'Purchase cancelled - escrow refunded',
+                'balance_before'  => $before,
+                'balance_after'   => $wallet->balance,
+            ]);
+
+            $purchase->property->update([
+                'status'           => 'sale',
+                'property_state'   => 'Valid',
+                'pending_buyer_id' => null,
+            ]);
+
+            $escrow->update([
+                'status'        => 'refunded_to_buyer',
+                'released_at'   => now(),
+                'release_reason'=> 'buyer_cancelled',
+            ]);
+            $purchase->update(['status' => 'cancelled']);
+
+            try {
+                $buyerNotification = new \App\Notifications\PropertyPurchaseCancelled($purchase);
+                Notification::send($user, $buyerNotification);
+                $this->createUserNotificationFromWebsocketData(
+                    $user,
+                    $buyerNotification,
+                    NotificationPurpose::PURCHASE_CANCELLED,
+                    $purchase->seller_id
+                );
+
+                $sellerNotification = new \App\Notifications\PurchaseCancelledByBuyer($purchase);
+                Notification::send($purchase->seller, $sellerNotification);
+                $this->createUserNotificationFromWebsocketData(
+                    $purchase->seller,
+                    $sellerNotification,
+                    NotificationPurpose::PURCHASE_CANCELLED,
+                    $user->id
+                );
+            } catch (Exception $e) {
+                Log::warning('Notification failed on cancelPurchase', ['error' => $e->getMessage()]);
+            }
+
+            return $this->success('Purchase cancelled and money refunded.');
+        });
+    }
+
+    // ====================================================
+    // ALL USER TRANSACTIONS
+    // ====================================================
+    public function getAllUserTransactions(Request $request)
+    {
+        $user = $request->user();
+        if (!$user) {
+            return $this->error('Authentication required.', 401);
+        }
+
+        $wallet = Wallet::with(['transactions' => function ($q) {
+            $q->orderBy('created_at', 'desc');
+        }])->where('user_id', $user->id)->first();
+
+        $purchases = PropertyPurchase::with(['property', 'escrow'])
+            ->where(function ($q) use ($user) {
+                $q->where('buyer_id', $user->id)
+                  ->orWhere('seller_id', $user->id);
+            })
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $rents = RentRequest::with(['property', 'escrow'])
+            ->where(function ($q) use ($user) {
+                $q->where('user_id', $user->id)
+                  ->orWhereHas('property', function ($qq) use ($user) {
+                      $qq->where('owner_id', $user->id);
+                  });
+            })
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return $this->success('All financial data retrieved.', [
+            'wallet'    => $wallet,
+            'purchases' => $purchases,
+            'rents'     => $rents,
+        ]);
+    }
+}

--- a/app/Jobs/ReleasePropertyEscrow.php
+++ b/app/Jobs/ReleasePropertyEscrow.php
@@ -1,0 +1,67 @@
+<?php
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\PropertyEscrow;
+use App\Models\Wallet;
+use App\Models\WalletTransaction;
+use Illuminate\Support\Facades\DB;
+
+class ReleaseEscrows extends Command
+{
+protected $signature = 'escrow:release';
+protected $description = 'Release locked property escrows after 24 hours if not cancelled';
+
+public function handle()
+{
+$now = now();
+$escrows = PropertyEscrow::with('purchase', 'purchase.property', 'purchase.seller')
+->where('status', 'locked')
+->where('scheduled_release_at', '<=', $now) ->get();
+
+    foreach ($escrows as $escrow) {
+    DB::transaction(function () use ($escrow) {
+    $purchase = $escrow->purchase;
+    $property = $purchase->property;
+    $seller = $purchase->seller;
+
+    // 1. Credit seller’s wallet
+    $wallet = Wallet::lockForUpdate()->firstOrCreate(
+    ['user_id' => $seller->id],
+    ['balance' => 0]
+    );
+    $before = $wallet->balance;
+    $wallet->increment('balance', $escrow->amount);
+
+    WalletTransaction::create([
+    'wallet_id' => $wallet->id,
+    'amount' => $escrow->amount,
+    'type' => 'sale_income',
+    'ref_id' => $purchase->id,
+    'ref_type' => 'property_purchase',
+    'description' => 'Escrow released to seller after 24h',
+    'balance_before' => $before,
+    'balance_after' => $wallet->balance,
+    ]);
+
+    // 2. Transfer ownership to buyer
+    $property->update([
+    'owner_id' => $purchase->buyer_id,
+    'status' => 'sold',
+    'property_state' => 'Valid',
+    'pending_buyer_id' => null,
+    ]);
+
+    // 3. Update purchase & escrow
+    $purchase->update(['status' => 'completed']);
+    $escrow->update([
+    'status' => 'released_to_seller', 
+    'released_at' => now(),
+    'release_reason' => 'auto_release_after_24h'
+    ]);
+    });
+    }
+
+    $this->info('Escrow release job executed.');
+    }
+    }

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -398,4 +398,24 @@ public function checkouts()
 {
     return $this->hasManyThrough(Checkout::class, RentRequest::class);
 }
+public function pendingBuyer(): BelongsTo
+{
+    return $this->belongsTo(User::class, 'pending_buyer_id');
+}
+
+public function propertyPurchases(): HasMany
+{
+    return $this->hasMany(PropertyPurchase::class);
+}
+
+public function activePurchase(): HasOne
+{
+    return $this->hasOne(PropertyPurchase::class)->whereIn('status', ['paid', 'pending']);
+}
+
+public function isUnderPurchase(): bool
+{
+    return $this->status === 'pending_transfer' && $this->pending_buyer_id !== null;
+}
+
 }

--- a/app/Models/PropertyEscrow.php
+++ b/app/Models/PropertyEscrow.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PropertyEscrow extends Model
+{
+    protected $fillable = [
+        'property_purchase_id',
+        'property_id',
+        'buyer_id',
+        'seller_id', 
+        'amount',
+        'status',
+        'locked_at',
+        'scheduled_release_at',
+        'released_at',
+        'release_reason',
+        'payment_breakdown',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'locked_at' => 'datetime',
+        'scheduled_release_at' => 'datetime',
+        'released_at' => 'datetime',
+        'payment_breakdown' => 'array',
+    ];
+
+    // ================= RELATIONSHIPS ================= //
+
+    public function propertyPurchase(): BelongsTo
+    {
+        return $this->belongsTo(PropertyPurchase::class);
+    }
+
+    public function property(): BelongsTo
+    {
+        return $this->belongsTo(Property::class);
+    }
+
+    public function buyer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'buyer_id');
+    }
+
+    public function seller(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'seller_id');
+    }
+
+    // ================= BUSINESS LOGIC ================= //
+
+    // Check if escrow is ready for auto-release
+    public function isReadyForRelease(): bool
+    {
+        return $this->status === 'locked'
+            && $this->scheduled_release_at?->isPast();
+    }
+
+    // ================= SCOPES ================= //
+
+    // Scope for escrows ready to be released
+    public function scopeReadyForRelease($query)
+    {
+        return $query->where('status', 'locked')
+                     ->where('scheduled_release_at', '<=', now());
+    }
+}

--- a/app/Models/PropertyPurchase.php
+++ b/app/Models/PropertyPurchase.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class PropertyPurchase extends Model
+{
+    protected $fillable = [
+        'property_id',
+        'buyer_id',
+        'seller_id',
+        'amount',
+        'status',
+        'payment_gateway',
+        'transaction_ref',
+        'idempotency_key',
+        'purchase_date',
+        'cancellation_deadline',
+        'completion_date',
+        'cancelled_at',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'purchase_date' => 'datetime',
+        'cancellation_deadline' => 'datetime',
+        'completion_date' => 'datetime',
+        'cancelled_at' => 'datetime',
+        'metadata' => 'array',
+    ];
+
+    // Relationships
+    public function property(): BelongsTo
+    {
+        return $this->belongsTo(Property::class);
+    }
+
+    public function buyer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'buyer_id');
+    }
+
+    public function seller(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'seller_id');
+    }
+
+    public function escrow(): HasOne
+    {
+        return $this->hasOne(PropertyEscrow::class);
+    }
+}

--- a/app/Models/RentRequest.php
+++ b/app/Models/RentRequest.php
@@ -94,5 +94,9 @@ public function hasCheckout()
 {
     return $this->checkout !== null;
 }
+public function escrow()
+{
+    return $this->hasOne(PropertyEscrow::class, 'property_purchase_id');
+}
 
 }

--- a/app/Notifications/PropertyPurchaseCancelled.php
+++ b/app/Notifications/PropertyPurchaseCancelled.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Notification;
+
+class PropertyPurchaseCancelled extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected $purchase;
+
+    public function __construct($purchase)
+    {
+        $this->purchase = $purchase;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message' => 'The purchase of property ' . $this->purchase->property->name . ' was cancelled.',
+        ];
+    }
+
+    public function toBroadcast($notifiable)
+    {
+        return new BroadcastMessage([
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message' => 'The purchase of property ' . $this->purchase->property->name . ' was cancelled.',
+        ]);
+    }
+}

--- a/app/Notifications/PropertyPurchaseInitiated.php
+++ b/app/Notifications/PropertyPurchaseInitiated.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Notification;
+
+class PropertyPurchaseInitiated extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected $purchase;
+
+    public function __construct($purchase)
+    {
+        $this->purchase = $purchase;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message' => 'Your purchase for property ' . $this->purchase->property->name . ' has been initiated.',
+        ];
+    }
+
+    public function toBroadcast($notifiable)
+    {
+        return new BroadcastMessage([
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message' => 'Your purchase for property ' . $this->purchase->property->name . ' has been initiated.',
+        ]);
+    }
+}

--- a/app/Notifications/PropertyPurchaseSuccessful.php
+++ b/app/Notifications/PropertyPurchaseSuccessful.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Notification;
+
+class PropertyPurchaseSuccessful extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected $purchase;
+
+    public function __construct($purchase)
+    {
+        $this->purchase = $purchase;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message' => 'Your purchase of the property ' . $this->purchase->property->name . ' was successful.',
+        ];
+    }
+
+    public function toBroadcast($notifiable)
+    {
+        return new BroadcastMessage([
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message' => 'Your purchase of the property ' . $this->purchase->property->name . ' was successful.',
+        ]);
+    }
+}

--- a/app/Notifications/PurchaseCancelled.php
+++ b/app/Notifications/PurchaseCancelled.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\PropertyPurchase;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class PurchaseCancelled extends Notification
+{
+    use Queueable;
+
+    protected $purchase;
+
+    public function __construct(PropertyPurchase $purchase)
+    {
+        $this->purchase = $purchase;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message'     => 'Your purchase has been cancelled and money refunded.',
+        ];
+    }
+
+    public function toBroadcast($notifiable)
+    {
+        return [
+            'data' => [
+                'purchase_id' => $this->purchase->id,
+                'property_id' => $this->purchase->property_id,
+                'message'     => 'Your purchase has been cancelled and money refunded.',
+            ]
+        ];
+    }
+}

--- a/app/Notifications/PurchaseCancelledByBuyer.php
+++ b/app/Notifications/PurchaseCancelledByBuyer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\PropertyPurchase;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class PurchaseCancelledByBuyer extends Notification
+{
+    use Queueable;
+
+    protected $purchase;
+
+    public function __construct(PropertyPurchase $purchase)
+    {
+        $this->purchase = $purchase;
+    }
+
+    public function via($notifiable)
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message'     => 'The buyer cancelled their purchase. Property is back for sale.',
+        ];
+    }
+
+    public function toBroadcast($notifiable)
+    {
+        return [
+            'data' => [
+                'purchase_id' => $this->purchase->id,
+                'property_id' => $this->purchase->property_id,
+                'message'     => 'The buyer cancelled their purchase. Property is back for sale.',
+            ]
+        ];
+    }
+}

--- a/app/Notifications/PurchaseInitiatedSeller.php
+++ b/app/Notifications/PurchaseInitiatedSeller.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\PropertyPurchase;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\DatabaseMessage;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+
+class PurchaseInitiatedSeller extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        protected PropertyPurchase $purchase
+    ) {}
+
+    public function via($notifiable)
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase($notifiable)
+    {
+        return [
+            'purchase_id' => $this->purchase->id,
+            'property_id' => $this->purchase->property_id,
+            'message'     => 'A buyer has initiated a purchase for your property.',
+        ];
+    }
+
+    public function toBroadcast($notifiable)
+    {
+        return new BroadcastMessage($this->toDatabase($notifiable));
+    }
+}

--- a/database/migrations/2025_09_22_112925_create_property_purchases_table.php
+++ b/database/migrations/2025_09_22_112925_create_property_purchases_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('property_purchases', function (Blueprint $table) {
+            $table->id(); // Standard auto-increment id
+            $table->foreignId('property_id')->constrained()->onDelete('cascade');
+            $table->foreignId('buyer_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('seller_id')->constrained('users')->onDelete('cascade');
+            $table->decimal('amount', 12, 2);
+            $table->enum('status', ['pending', 'paid', 'completed', 'cancelled', 'refunded']);
+            $table->string('payment_gateway')->nullable();
+            $table->string('transaction_ref')->nullable();
+            $table->string('idempotency_key')->unique();
+$table->timestamp('purchase_date')->nullable();
+$table->timestamp('cancellation_deadline')->nullable();
+            $table->timestamp('completion_date')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('property_purchases');
+    }
+};

--- a/database/migrations/2025_09_22_112959_create_property_escrows_table.php
+++ b/database/migrations/2025_09_22_112959_create_property_escrows_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('property_escrows', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_purchase_id')->constrained()->onDelete('cascade');
+            $table->foreignId('property_id')->constrained()->onDelete('cascade');
+            $table->foreignId('buyer_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('seller_id')->constrained('users')->onDelete('cascade');
+            $table->decimal('amount', 12, 2);
+            $table->enum('status', ['locked', 'released_to_seller', 'refunded_to_buyer']);
+$table->timestamp('locked_at')->nullable();
+$table->timestamp('scheduled_release_at')->nullable();
+            $table->timestamp('released_at')->nullable();
+            $table->text('release_reason')->nullable();
+            $table->json('payment_breakdown')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('property_escrows');
+    }
+};

--- a/database/migrations/2025_09_22_113429_add_purchase_fields_to_properties_table.php
+++ b/database/migrations/2025_09_22_113429_add_purchase_fields_to_properties_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            // Add pending buyer field (nullable FK to users)
+            $table->unsignedBigInteger('pending_buyer_id')->nullable()->after('owner_id');
+            
+            // Add transfer scheduled timestamp (nullable to avoid MySQL default issues)
+            $table->timestamp('transfer_scheduled_at')->nullable()->after('updated_at');
+
+            // Add foreign key constraint
+            $table->foreign('pending_buyer_id')
+                  ->references('id')
+                  ->on('users')
+                  ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            // Drop foreign key first
+            $table->dropForeign(['pending_buyer_id']);
+
+            // Drop the columns
+            $table->dropColumn(['pending_buyer_id', 'transfer_scheduled_at']);
+        });
+    }
+};

--- a/database/migrations/2025_09_22_123501_alter_wallet_transactions_type_column.php
+++ b/database/migrations/2025_09_22_123501_alter_wallet_transactions_type_column.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('wallet_transactions', function (Blueprint $table) {
+            $table->string('type', 50)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('wallet_transactions', function (Blueprint $table) {
+            // If you want to go back to enum (not recommended)
+            $table->enum('type', [
+                'deposit',
+                'withdrawal',
+                'purchase',
+                'refund',
+                'transfer'
+            ])->change();
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,6 +41,9 @@ use App\Http\Controllers\UserBalanceController;
 // Withdraw
 use App\Http\Controllers\WithdrawalController;
 
+// Buy Property
+use App\Http\Controllers\PropertyPurchaseController;
+
 
 Route::get('/user', function (Request $request) {
     return $request->user();
@@ -94,6 +97,16 @@ Route::prefix('propertiesList')->group(function () {
     Route::get('/{id}', [PropertyController::class, 'showAnyone']);
 });
 // Protected routes
+
+// Property Purchase routes
+Route::middleware('auth:api')->group(function () {
+    Route::post('/properties/{id}/purchase', [PropertyPurchaseController::class, 'payForOwn']);
+    Route::post('/purchases/{id}/cancel', [PropertyPurchaseController::class, 'cancelPurchase']);
+    Route::get('/purchases/cancellable', [PropertyPurchaseController::class, 'getUserCancellablePurchases']);
+    Route::get('/purchases', [PropertyPurchaseController::class, 'getAllPurchases']);
+    Route::get('/user/transactions', [PropertyPurchaseController::class, 'getAllUserTransactions']);
+});
+
 Route::middleware('auth:api')->group(function () {
 
     Route::post('profile', [AuthenticationController::class, 'profile']);


### PR DESCRIPTION
…w with notifications

- Added full purchase lifecycle using escrow: • Buyer can pay for property -> creates PropertyPurchase + PropertyEscrow • Escrow auto-releases to seller after 24h if not cancelled • Buyer can cancel purchase within 24h -> refund to wallet, property reset to sale

- Added strict validations: • User must be authenticated and active • Property must exist, be for sale, valid, and owned by an active seller • Prevent self-purchase and duplicate purchases • Enforce idempotency keys to avoid duplicate transactions • Validate expected price vs property price

- Implemented wallet integration: • Escrow locks funds on purchase • Refunds returned to buyer’s wallet if cancelled • Sale income credited to seller’s wallet on escrow release • WalletTransaction records created for all movements

- Added persistent notifications: • Buyer and seller notified on purchase, cancellation, and release • Notifications stored in user_notifications table for reliability

- Added user financial history: • Wallet balance + transactions • Purchase history with escrow details • Rent requests with escrow status

- Added background job escrow:release to auto-complete purchases after 24h