### PR TITLE
fix: Convert enum to string value for UserNotification creation

### DIFF
--- a/app/Http/Controllers/PropertyPurchaseController.php
+++ b/app/Http/Controllers/PropertyPurchaseController.php
@@ -66,7 +66,7 @@ class PropertyPurchaseController extends Controller
                 'user_id'   => $recipient->id,
                 'sender_id' => $senderId,
                 'entity_id' => $entityId,
-                'purpose'   => $purpose,
+                'purpose'   => $purpose->value,
                 'title'     => $purpose->label(),
                 'message'   => $message,
                 'is_read'   => false,

--- a/app/Http/Controllers/RentRequestController.php
+++ b/app/Http/Controllers/RentRequestController.php
@@ -76,7 +76,7 @@ Log::info('Inserting notification', [
                 'user_id' => $recipient->id,
                 'sender_id' => $senderId,
                 'entity_id' => $entityId,
-                'purpose' => $purpose,
+                'purpose' => $purpose->value,
                 'title' => $purpose->label(),
                 'message' => $message,
                 'is_read' => false,

--- a/app/Services/PaymobPaymentService.php
+++ b/app/Services/PaymobPaymentService.php
@@ -56,7 +56,7 @@ class PaymobPaymentService extends BasePaymentService
             'user_id'   => $recipient->id,
             'sender_id' => $senderId,
             'entity_id' => $entityId,
-            'purpose'   => $purpose,
+            'purpose'   => $purpose->value,
             'title'     => $purpose->label(),
             'message'   => $message,
             'is_read'   => false,


### PR DESCRIPTION
- Change 'purpose' =>  to 'purpose' => ->value
- Fixes database insertion issues where enum objects couldn't be stored
- Applied to PropertyPurchaseController, PaymobPaymentService, and RentRequestController